### PR TITLE
Move confirmed models list to its own doc

### DIFF
--- a/CONFIRMED_MODELS.md
+++ b/CONFIRMED_MODELS.md
@@ -1,0 +1,26 @@
+# Confirmed Working Models
+
+**Thank you.** Seriously. Every entry on this list exists because somebody took the time to plug in their vacuum, run shark2mqtt, and then come back to tell me it worked. That feedback is gold. It's the only way I find out which models behave like mine and which ones have their own quirks -- I only own two robots, so without these reports I'd be flying blind.
+
+If your model isn't listed and shark2mqtt works for you, please drop a note on [issue #10](https://github.com/CamSoper/shark2mqtt/issues/10) (or open a new issue with the "confirmed working" tag) so I can add you to the list. Model number, region, and any quirks you noticed are all I need. You absolutely do not have to open a PR for this -- a one-line comment is plenty.
+
+Other SharkNinja robot vacuums likely work too. This list reflects what's been reported in the wild, not the limit of what's supported.
+
+## The List
+
+| Model | Region | Reported by | Notes |
+|---|---|---|---|
+| UR250BEXUS (Shark AI Ultra, UR2500SR) | US | [@CamSoper](https://github.com/CamSoper) | Dev hardware |
+| UR2360EEUS (Shark Matrix Plus, UR2360S) | US | [@CamSoper](https://github.com/CamSoper) | Dev hardware |
+| RV2110DDUS | US | [@gogorichie](https://github.com/gogorichie) ([#9](https://github.com/CamSoper/shark2mqtt/issues/9)) | |
+| RV2820VEUS | US | [@400HPMustang](https://github.com/400HPMustang) ([#8](https://github.com/CamSoper/shark2mqtt/issues/8)) | Pause command not honored by vacuum |
+| RV2820YECA (PowerDetect 2-in-1) | Canada (`us` region) | [@hslabbert](https://github.com/hslabbert) ([#4](https://github.com/CamSoper/shark2mqtt/issues/4)) | |
+| AV251WAXUS | US | [@Slivacki](https://github.com/Slivacki) ([#1](https://github.com/CamSoper/shark2mqtt/issues/1)) | |
+| UR250BE0US | US | [@Pau1ey](https://github.com/Pau1ey) ([#8](https://github.com/CamSoper/shark2mqtt/issues/8)) | |
+| Shark PowerDetect (model unspecified) | EU | [@hjennerway](https://github.com/hjennerway) ([#3](https://github.com/CamSoper/shark2mqtt/issues/3)) | |
+| RV2520A0US | US | [@emann3](https://github.com/emann3) ([#10](https://github.com/CamSoper/shark2mqtt/issues/10)) | |
+| RV2520AZUS | US | [@emann3](https://github.com/emann3) ([#10](https://github.com/CamSoper/shark2mqtt/issues/10)) | |
+| AV251WAYUS | US | [@emann3](https://github.com/emann3) ([#10](https://github.com/CamSoper/shark2mqtt/issues/10)) | |
+| RV2820ZEUS (vac/mop) | US | [@emann3](https://github.com/emann3) ([#10](https://github.com/CamSoper/shark2mqtt/issues/10)) | |
+| RV750R01US | US | [@rmiles7721](https://github.com/rmiles7721) ([#10](https://github.com/CamSoper/shark2mqtt/issues/10)) | |
+| AV2870ZEUS | US | James Little (via email) | Firmware `V0.0.32-3d-20250714V6.6.1` |

--- a/CONFIRMED_MODELS.md
+++ b/CONFIRMED_MODELS.md
@@ -2,7 +2,7 @@
 
 **Thank you.** Seriously. Every entry on this list exists because somebody took the time to plug in their vacuum, run shark2mqtt, and then come back to tell me it worked. That feedback is gold. It's the only way I find out which models behave like mine and which ones have their own quirks -- I only own two robots, so without these reports I'd be flying blind.
 
-If your model isn't listed and shark2mqtt works for you, please drop a note on [issue #10](https://github.com/CamSoper/shark2mqtt/issues/10) (or open a new issue with the "confirmed working" tag) so I can add you to the list. Model number, region, and any quirks you noticed are all I need. You absolutely do not have to open a PR for this -- a one-line comment is plenty.
+If your model isn't listed and shark2mqtt works for you, please drop a note on [issue #10](https://github.com/CamSoper/shark2mqtt/issues/10) so I can add you to the list. Model number, region, and any quirks you noticed are all I need. You can also just submit a PR adding yourself to this list.
 
 Other SharkNinja robot vacuums likely work too. This list reflects what's been reported in the wild, not the limit of what's supported.
 

--- a/README.md
+++ b/README.md
@@ -7,18 +7,7 @@ Bridge SharkNinja robot vacuums to [Home Assistant](https://www.home-assistant.i
 
 ## Confirmed Working Models
 
-Models below have been confirmed working by users in the wild. Other SharkNinja robot vacuums likely work too -- this list reflects what's been reported, not the limit of what's supported.
-
-| Model | Region | Reported by | Notes |
-|---|---|---|---|
-| UR250BEXUS (Shark AI Ultra, UR2500SR) | US | [@CamSoper](https://github.com/CamSoper) | Dev hardware |
-| UR2360EEUS (Shark Matrix Plus, UR2360S) | US | [@CamSoper](https://github.com/CamSoper) | Dev hardware |
-| RV2110DDUS | US | [@gogorichie](https://github.com/gogorichie) ([#9](https://github.com/CamSoper/shark2mqtt/issues/9)) | |
-| RV2820VEUS | US | [@400HPMustang](https://github.com/400HPMustang) ([#8](https://github.com/CamSoper/shark2mqtt/issues/8)) | Pause command not honored by vacuum |
-| RV2820YECA (PowerDetect 2-in-1) | Canada (`us` region) | [@hslabbert](https://github.com/hslabbert) ([#4](https://github.com/CamSoper/shark2mqtt/issues/4)) | |
-| AV251WAXUS | US | [@Slivacki](https://github.com/Slivacki) ([#1](https://github.com/CamSoper/shark2mqtt/issues/1)) | |
-| UR250BE0US | US | [@Pau1ey](https://github.com/Pau1ey) ([#8](https://github.com/CamSoper/shark2mqtt/issues/8)) | |
-| Shark PowerDetect (model unspecified) | EU | [@hjennerway](https://github.com/hjennerway) ([#3](https://github.com/CamSoper/shark2mqtt/issues/3)) | |
+A growing list of models confirmed working in the wild lives in [CONFIRMED_MODELS.md](CONFIRMED_MODELS.md). Other SharkNinja robot vacuums likely work too -- the list reflects what's been reported, not the limit of what's supported. If your model isn't on it, please let me know.
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

- Split the "Confirmed Working Models" table out of the README into a new top-level `CONFIRMED_MODELS.md`, linked from the README.
- Added a warm thank-you intro to the new doc encouraging more reports.
- Added the model reports from #10:
  - `RV2520A0US`, `RV2520AZUS`, `AV251WAYUS`, `RV2820ZEUS` (vac/mop) — @emann3
  - `RV750R01US` — @rmiles7721
- Added `AV2870ZEUS` (firmware `V0.0.32-3d-20250714V6.6.1`) reported by James Little via email.

Closes #10.

## Test plan

- [ ] `CONFIRMED_MODELS.md` renders correctly on GitHub (table + links).
- [ ] README link to `CONFIRMED_MODELS.md` resolves.
- [ ] Spot-check that every reporter's GitHub handle links to the right profile.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VVcxDtCoSYSMzhK9hZZTCC)_