### PR TITLE
Add UR26503CUS model to confirmed models list

### DIFF
--- a/CONFIRMED_MODELS.md
+++ b/CONFIRMED_MODELS.md
@@ -25,3 +25,4 @@ Other SharkNinja robot vacuums likely work too. This list reflects what's been r
 | RV750R01US | US | [@rmiles7721](https://github.com/rmiles7721) ([#10](https://github.com/CamSoper/shark2mqtt/issues/10)) | |
 | AV2870ZEUS | US | James Little (via email) | Firmware `V0.0.32-3d-20250714V6.6.1` |
 | AV301WXEUK | EU | [@Adouken](https://github.com/Adouken) | Works with both wet and dry commands
+| UR26503CUS | US | [@smacdmac101](https://github.com/smacdmac101) | Two units tested |

--- a/CONFIRMED_MODELS.md
+++ b/CONFIRMED_MODELS.md
@@ -25,4 +25,4 @@ Other SharkNinja robot vacuums likely work too. This list reflects what's been r
 | RV750R01US | US | [@rmiles7721](https://github.com/rmiles7721) ([#10](https://github.com/CamSoper/shark2mqtt/issues/10)) | |
 | AV2870ZEUS | US | James Little (via email) | Firmware `V0.0.32-3d-20250714V6.6.1` |
 | AV301WXEUK | EU | [@Adouken](https://github.com/Adouken) | Works with both wet and dry commands
-| UR26503CUS | US | [@smacdmac101](https://github.com/smacdmac101) | Two units tested |
+| UR26503CUS | US | [@smacdmac101](https://github.com/smacdmac101) | Two units tested; eco and normal fan speeds appear reversed |


### PR DESCRIPTION
Confirmed working with two UR26503CUS units in the US region.

Tested successfully:

* MQTT discovery
* Start / pause / stop
* Return to dock
* Battery reporting
* Charging and docked state
* Error reporting
* RSSI reporting
* Fan speed controls (eco, normal, max)

Known quirk:

* Eco and normal fan speed labels appear reversed. Eco produces noticeably higher suction than normal.
