### PR TITLE
Support plain-text send_command payloads and expose mop modes

### DIFF
--- a/src/mqtt_client.py
+++ b/src/mqtt_client.py
@@ -445,7 +445,14 @@ class MqttClient:
                           clean_count: 1, clean_type: "dry"}
         """
         import json as _json
-        data = _json.loads(payload)
+        # HA may publish the command as raw JSON ({"command": "..."}) or as a
+        # plain command string (e.g. "vacuum_and_mop"). Accept both.
+        try:
+            data = _json.loads(payload)
+        except (_json.JSONDecodeError, TypeError):
+            data = {"command": payload.strip(), "params": {}}
+        if not isinstance(data, dict):
+            data = {"command": str(data).strip(), "params": {}}
         logger.debug("send_command raw data: %r", data)
         command = data.get("command", "")
         params = data.get("params", data.get("param", {}))

--- a/src/skegox_api.py
+++ b/src/skegox_api.py
@@ -293,13 +293,15 @@ class SkegoxApi:
         logger.info("Set %s=%s on %s", property_name, value, snd)
 
     async def send_command(self, snd: str, command: str) -> None:
-        """Send a vacuum command (start, stop, pause, return, locate)."""
+        """Send a vacuum command (start, stop, pause, return, locate, mop)."""
         command_map = {
             "start": ("Operating_Mode", 2),
             "stop": ("Operating_Mode", 0),
             "pause": ("Operating_Mode", 1),
             "return_to_base": ("Operating_Mode", 3),
             "locate": ("Find_Device", 1),
+            "mop": ("Operating_Mode", 7),
+            "vacuum_and_mop": ("Operating_Mode", 8),
         }
         if command not in command_map:
             logger.warning("Unknown command: %s", command)


### PR DESCRIPTION
## Summary

Triage pass over open issues. This PR bundles the two fixes that can be addressed in code right now.

### Issue #17 — `vacuum.send_command` fails on plain-text payloads, and Skegox mop modes aren't exposed

Two changes, matching the diagnosis (and proposed fix) from @deftones064:

1. **Plain-text payloads** (`src/mqtt_client.py`): `_handle_send_command()` previously did `json.loads(payload)` unconditionally, which raised `JSONDecodeError` when HA published a bare command string like `vacuum_and_mop`. It now falls back to treating the payload as a plain command string when it isn't valid JSON (and guards against non-dict JSON).

2. **Mop modes** (`src/skegox_api.py`): the Skegox `command_map` only exposed start/stop/pause/return/locate. Added `mop` → `Operating_Mode=7` and `vacuum_and_mop` → `Operating_Mode=8` (these enum values already existed in `const.py`).

After both changes, `vacuum.send_command` with `command: vacuum_and_mop` sets `Operating_Mode=8` as expected.

### Issue #18 — RV2800ZEUK unable to select vacuum/mop

The "can't select vacuum or mop" part has the same root cause as #17 issue 2: the mop / vacuum-and-mop modes weren't reachable through `send_command`. This PR exposes them, so the mode-selection complaint should be resolved **for Skegox-backed devices** via:

```yaml
action: vacuum.send_command
target:
  entity_id: vacuum.your_robot
data:
  command: vacuum_and_mop   # or: mop
```

Note: #18 also reports an Ayla room-name mismatch ("Hallway" vs "Laundry Room") that is a Shark-side data sync problem, not something this PR addresses.

---

Fixes #17 
Fixes #18 

(Please reopen either or both if this doesn't fix it)
