### PR TITLE
Treat charging as docked and stop republishing unchanged discovery

### DIFF
--- a/src/mqtt_client.py
+++ b/src/mqtt_client.py
@@ -30,6 +30,7 @@ class MqttClient:
         self._clean_modes: dict[str, str] = {}  # device_id -> "Normal" or "Matrix"
         self._fan_speed_overrides: dict[str, str] = {}  # device_id -> user-set speed
         self._published_rooms: dict[str, set[str]] = {}  # device_id -> room slugs
+        self._discovery_sigs: dict[str, str] = {}  # device_id -> last published signature
 
     async def __aenter__(self) -> MqttClient:
         will = aiomqtt.Will(
@@ -69,6 +70,17 @@ class MqttClient:
         dsn = device.dsn
         uid = f"shark2mqtt_{dsn}"
         slug = re.sub(r"[^a-z0-9]+", "_", device.product_name.lower()).strip("_")
+
+        # Discovery configs are retained, so republishing every poll cycle
+        # is pure noise (issue #29). Skip unless something that feeds the
+        # configs (device info or room list) actually changed.
+        sig = json.dumps(
+            {"device": device.device_info, "rooms": device.rooms},
+            sort_keys=True,
+        )
+        if self._discovery_sigs.get(dsn) == sig:
+            logger.debug("Discovery unchanged for %s (%s), skipping", device.product_name, dsn)
+            return
 
         # Vacuum entity
         await self._publish(
@@ -267,6 +279,7 @@ class MqttClient:
             )
             logger.info("Removed stale room button %s for %s", room_slug, dsn)
         self._published_rooms[dsn] = current_room_slugs
+        self._discovery_sigs[dsn] = sig
 
         logger.info("Published HA discovery for %s (%s)", device.product_name, dsn)
 

--- a/src/shark_device.py
+++ b/src/shark_device.py
@@ -190,7 +190,13 @@ class SharkVacuum:
 
     @property
     def is_docked(self) -> bool:
-        return self._get_int_prop(PROP_GET_DOCKED_STATUS) == 1
+        # Charging implies docked: the robot can't charge off the dock,
+        # but skegox can report a stale DockedStatus=0 for days after a
+        # completed return (issue #29).
+        return (
+            self._get_int_prop(PROP_GET_DOCKED_STATUS) == 1
+            or self.is_charging
+        )
 
     @property
     def error_code(self) -> int:

--- a/tests/test_shark_device.py
+++ b/tests/test_shark_device.py
@@ -1,0 +1,75 @@
+"""Tests for SharkVacuum state mapping and MQTT discovery dedup."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.mqtt_client import MqttClient
+from src.shark_device import SharkVacuum
+
+from .conftest import make_skegox_device
+
+
+def make_vacuum(
+    operating_mode: int = 0,
+    docked_status: int = 1,
+    charging_status: int = 0,
+) -> SharkVacuum:
+    data = make_skegox_device(operating_mode=operating_mode)
+    reported = data["shadow"]["properties"]["reported"]
+    reported["DockedStatus"]["value"] = docked_status
+    reported["Charging_Status"]["value"] = charging_status
+    return SharkVacuum.from_skegox(data)
+
+
+class TestDockedState:
+    def test_docked_status_docked(self):
+        vac = make_vacuum(operating_mode=0, docked_status=1)
+        assert vac.is_docked
+        assert vac.ha_state == "docked"
+
+    def test_charging_implies_docked(self):
+        # Issue #29: skegox reported DockedStatus=0 + Operating_Mode=RETURN
+        # for days while the robot sat on the dock charging.
+        vac = make_vacuum(operating_mode=3, docked_status=0, charging_status=1)
+        assert vac.is_docked
+        assert vac.ha_state == "docked"
+
+    def test_returning_when_not_charging(self):
+        vac = make_vacuum(operating_mode=3, docked_status=0, charging_status=0)
+        assert not vac.is_docked
+        assert vac.ha_state == "returning"
+
+    def test_cleaning_not_masked_by_dock(self):
+        vac = make_vacuum(operating_mode=2, docked_status=1)
+        assert vac.ha_state == "cleaning"
+
+
+class TestDiscoveryDedup:
+    @pytest.fixture
+    def client(self, mock_config):
+        client = MqttClient(mock_config)
+        client._publish = AsyncMock()
+        return client
+
+    @pytest.mark.asyncio
+    async def test_unchanged_discovery_skipped(self, client):
+        vac = make_vacuum()
+        await client.publish_discovery(vac)
+        first_count = client._publish.call_count
+        assert first_count > 0
+
+        await client.publish_discovery(vac)
+        assert client._publish.call_count == first_count
+
+    @pytest.mark.asyncio
+    async def test_room_change_republishes(self, client):
+        vac = make_vacuum()
+        await client.publish_discovery(vac)
+        first_count = client._publish.call_count
+
+        vac.rooms = ["Kitchen"]
+        await client.publish_discovery(vac)
+        assert client._publish.call_count > first_count


### PR DESCRIPTION
Fixes #29.

The skegox shadow can report a stale `DockedStatus=0` (with `Operating_Mode=RETURN`) for days after a completed return, while `Charging_Status` stays accurate. Since a robot can't charge off the dock, `is_docked` now also considers charging. This fixes the stuck "returning" state and the endless 20s active-poll loop it caused.

Also stops republishing HA discovery configs every poll cycle -- they're retained, so they only need to go out when the device info or room list actually changes. This kills the "Published HA discovery" log spam.

Includes tests for both.