### PR TITLE
Add error code 48 (mop pad missing)

### DIFF
--- a/src/const.py
+++ b/src/const.py
@@ -146,4 +146,5 @@ ERROR_CODES: dict[int, str] = {
     24: "Critical low battery",
     26: "Dustbin blockage",
     40: "Dustbin is blocked",
+    48: "Mop pad missing",  # reported on RV2820YEUS (issue #27)
 }


### PR DESCRIPTION
Adds a friendly string for `Error_Code 48`, reported on RV2820YEUS in #27 -- the robot raises it when a mop run starts without the pad attached.

Just the error table entry; the mode-mapping work from #27 is being handled separately.