### PR TITLE
Add mop water flow level control (Flow_Mode)

### DIFF
--- a/src/ayla_api.py
+++ b/src/ayla_api.py
@@ -22,6 +22,7 @@ from tenacity import (
 from .const import (
     POWER_MODE_BY_NAME,
     PROP_SET_FIND_DEVICE,
+    PROP_SET_FLOW_MODE,
     PROP_SET_OPERATING_MODE,
     PROP_SET_POWER_MODE,
     REGIONS,
@@ -566,6 +567,18 @@ class AylaApi:
             logger.warning("Unknown fan speed: %s", speed)
             return
         await self.set_device_property(dsn, PROP_SET_POWER_MODE, int(mode))
+
+    async def set_water_flow(self, dsn: str, level: str) -> None:
+        """Set mop water flow level via Ayla property datapoint.
+
+        Same 0/1/2 scale as Power_Mode; only applies to vac+mop combo
+        models with Flow_Mode in their shadow.
+        """
+        mode = POWER_MODE_BY_NAME.get(level)
+        if mode is None:
+            logger.warning("Unknown water flow level: %s", level)
+            return
+        await self.set_device_property(dsn, PROP_SET_FLOW_MODE, int(mode))
 
     async def clean_rooms(
         self,

--- a/src/const.py
+++ b/src/const.py
@@ -124,11 +124,16 @@ PROP_GET_RUN_TIME_CUMULATIVE = "GET_RunTimeCumulative"
 PROP_GET_REPLACE_BATTERY = "GET_ReplaceBattery"
 PROP_GET_RECOMMEND_RANDR = "GET_RecommendRandR"
 PROP_GET_SCHEDULE = "GET_Schedule"
+# Mop water flow level (vacuum+mop combo models). Shares the same 0/1/2
+# eco/normal/max scale as Power_Mode — confirmed against the SharkClean
+# app's "Water Flow Level" slider on a RV2820YEUS unit.
+PROP_GET_FLOW_MODE = "GET_Flow_Mode"
 
 # Write properties (used with POST /datapoints.json)
 PROP_SET_OPERATING_MODE = "SET_Operating_Mode"
 PROP_SET_POWER_MODE = "SET_Power_Mode"
 PROP_SET_FIND_DEVICE = "SET_Find_Device"
+PROP_SET_FLOW_MODE = "SET_Flow_Mode"
 
 # Error code descriptions
 # Sources: sharkiqlibs/sharkiq, ayla-iot-unofficial, Hubitat SharkIQ driver,

--- a/src/main.py
+++ b/src/main.py
@@ -45,6 +45,9 @@ class CommandRouter:
     async def set_fan_speed(self, device_id: str, speed: str) -> None:
         await self._api_for(device_id).set_fan_speed(device_id, speed)
 
+    async def set_water_flow(self, device_id: str, level: str) -> None:
+        await self._api_for(device_id).set_water_flow(device_id, level)
+
     async def clean_rooms(
         self,
         device_id: str,

--- a/src/mqtt_client.py
+++ b/src/mqtt_client.py
@@ -108,6 +108,28 @@ class MqttClient:
             retain=True,
         )
 
+        # Water flow level select (mop water flow — vac+mop combo models
+        # only; harmless no-op on the device for vac-only models since we
+        # simply won't have a truthy water_flow attribute to key off of).
+        await self._publish(
+            f"{HA_DISCOVERY_PREFIX}/select/{uid}_water_flow/config",
+            {
+                "name": "Water Flow Level",
+                "unique_id": f"{uid}_water_flow",
+                "object_id": f"{slug}_water_flow",
+                "command_topic": f"{self._prefix}/{dsn}/set_water_flow",
+                "state_topic": f"{self._prefix}/{dsn}/attributes",
+                "value_template": "{{ value_json.water_flow }}",
+                "options": ["eco", "normal", "max"],
+                "icon": "mdi:water-percent",
+                "availability_topic": f"{self._prefix}/{dsn}/available",
+                "payload_available": "online",
+                "payload_not_available": "offline",
+                "device": device.device_info,
+            },
+            retain=True,
+        )
+
         # Battery sensor
         await self._publish(
             f"{HA_DISCOVERY_PREFIX}/sensor/{uid}_battery/config",
@@ -469,6 +491,7 @@ class MqttClient:
 
         await self._client.subscribe(f"{self._prefix}/+/command")
         await self._client.subscribe(f"{self._prefix}/+/set_fan_speed")
+        await self._client.subscribe(f"{self._prefix}/+/set_water_flow")
         await self._client.subscribe(f"{self._prefix}/+/send_command")
         await self._client.subscribe(f"{self._prefix}/+/clean_room")
         await self._client.subscribe(f"{self._prefix}/+/clean_mode")
@@ -495,6 +518,10 @@ class MqttClient:
                     logger.info("Fan speed received: %s for %s", speed, device_id)
                     self._fan_speed_overrides[device_id] = speed
                     await command_handler.set_fan_speed(device_id, speed)
+                elif topic.endswith("/set_water_flow"):
+                    level = payload.strip().lower()
+                    logger.info("Water flow level received: %s for %s", level, device_id)
+                    await command_handler.set_water_flow(device_id, level)
                 elif topic.endswith("/send_command"):
                     logger.info("send_command received for %s", device_id)
                     await self._handle_send_command(

--- a/src/mqtt_client.py
+++ b/src/mqtt_client.py
@@ -29,6 +29,7 @@ class MqttClient:
         self._client: aiomqtt.Client | None = None
         self._clean_modes: dict[str, str] = {}  # device_id -> "Normal" or "Matrix"
         self._fan_speed_overrides: dict[str, str] = {}  # device_id -> user-set speed
+        self._water_flow_overrides: dict[str, str] = {}  # device_id -> user-set flow level
         self._published_rooms: dict[str, set[str]] = {}  # device_id -> room slugs
         self._discovery_sigs: dict[str, str] = {}  # device_id -> last published signature
 
@@ -443,8 +444,13 @@ class MqttClient:
         if device.is_docked and dsn in self._fan_speed_overrides:
             state_payload["fan_speed"] = self._fan_speed_overrides[dsn]
 
+        attributes_payload = device.to_attributes_payload()
+        # Same dock-reports-eco quirk applies to water_flow (mop flow level).
+        if device.is_docked and dsn in self._water_flow_overrides:
+            attributes_payload["water_flow"] = self._water_flow_overrides[dsn]
+
         await self._publish(f"{self._prefix}/{dsn}/state", state_payload, retain=True)
-        await self._publish(f"{self._prefix}/{dsn}/attributes", device.to_attributes_payload(), retain=True)
+        await self._publish(f"{self._prefix}/{dsn}/attributes", attributes_payload, retain=True)
         await self._publish(f"{self._prefix}/{dsn}/available", available, retain=True)
 
         # Fire error event if error_code changed to non-zero
@@ -521,6 +527,7 @@ class MqttClient:
                 elif topic.endswith("/set_water_flow"):
                     level = payload.strip().lower()
                     logger.info("Water flow level received: %s for %s", level, device_id)
+                    self._water_flow_overrides[device_id] = level
                     await command_handler.set_water_flow(device_id, level)
                 elif topic.endswith("/send_command"):
                     logger.info("send_command received for %s", device_id)

--- a/src/shark_device.py
+++ b/src/shark_device.py
@@ -22,6 +22,7 @@ from .const import (
     PROP_GET_EVACUATE_RESUME_STATUS,
     PROP_GET_EVACUATING,
     PROP_GET_EXTENDED_ERROR_CODE,
+    PROP_GET_FLOW_MODE,
     PROP_GET_OPERATING_MODE,
     PROP_GET_POWER_MODE,
     PROP_GET_RECOMMEND_RANDR,
@@ -257,6 +258,24 @@ class SharkVacuum:
         return POWER_MODE_NAMES.get(mode, "normal")
 
     @property
+    def flow_mode(self) -> PowerMode | None:
+        """Mop water flow level (vac+mop combo models). Same 0/1/2 scale
+        as power_mode (eco/normal/max); confirmed against the SharkClean
+        app's "Water Flow Level" slider."""
+        val = self._get_int_prop(PROP_GET_FLOW_MODE, -1)
+        try:
+            return PowerMode(val)
+        except ValueError:
+            return None
+
+    @property
+    def water_flow(self) -> str:
+        mode = self.flow_mode
+        if mode is None:
+            return "normal"
+        return POWER_MODE_NAMES.get(mode, "normal")
+
+    @property
     def rssi(self) -> int:
         # Some models report RSSI as positive, others as negative dBm.
         # Real WiFi RSSI is always ≤ 0 dBm, so normalize to negative.
@@ -352,6 +371,7 @@ class SharkVacuum:
             "run_time_cumulative": self.run_time_cumulative,
             "replace_battery": self.replace_battery,
             "recommend_rest_and_recharge": self.recommend_rest_and_recharge,
+            "water_flow": self.water_flow,
         }
         if self.rooms:
             attrs["rooms"] = self.rooms

--- a/src/skegox_api.py
+++ b/src/skegox_api.py
@@ -318,6 +318,21 @@ class SkegoxApi:
             return
         await self.set_desired_property(snd, "Power_Mode", val)
 
+    async def set_water_flow(self, snd: str, level: str) -> None:
+        """Set mop water flow level (eco, normal, max).
+
+        Same 0/1/2 scale as Power_Mode; confirmed against the SharkClean
+        app's "Water Flow Level" slider on a vacuum+mop combo model
+        (RV2820YEUS). Only applies to devices with a mop tank — devices
+        without Flow_Mode in their shadow will just no-op the PATCH.
+        """
+        speed_map = {"eco": 0, "normal": 1, "max": 2}
+        val = speed_map.get(level.lower())
+        if val is None:
+            logger.warning("Unknown water flow level: %s", level)
+            return
+        await self.set_desired_property(snd, "Flow_Mode", val)
+
     async def clean_rooms(
         self,
         snd: str,

--- a/tests/test_shark_device.py
+++ b/tests/test_shark_device.py
@@ -89,10 +89,38 @@ class TestDockAndMaintenanceProperties:
             "is_evacuating", "evacuate_state", "evacuate_resume_status",
             "dock_error_code", "dock_knob_status", "warning_code",
             "extended_error_code", "run_time_cumulative", "replace_battery",
-            "recommend_rest_and_recharge",
+            "recommend_rest_and_recharge", "water_flow",
         ):
             assert key in attrs
         assert "schedule" not in attrs  # omitted when empty
+
+
+class TestWaterFlow:
+    """Mop water flow level — mirrors Power_Mode's 0/1/2 eco/normal/max scale."""
+
+    def test_defaults_to_normal_when_absent(self):
+        vac = make_vacuum()
+        assert vac.flow_mode is None
+        assert vac.water_flow == "normal"
+
+    def test_reads_flow_mode_max(self):
+        data = make_skegox_device()
+        data["shadow"]["properties"]["reported"]["Flow_Mode"] = {"value": 2}
+        vac = SharkVacuum.from_skegox(data)
+        assert vac.water_flow == "max"
+
+    def test_reads_flow_mode_eco(self):
+        data = make_skegox_device()
+        data["shadow"]["properties"]["reported"]["Flow_Mode"] = {"value": 0}
+        vac = SharkVacuum.from_skegox(data)
+        assert vac.water_flow == "eco"
+
+    def test_invalid_flow_mode_falls_back_to_normal(self):
+        data = make_skegox_device()
+        data["shadow"]["properties"]["reported"]["Flow_Mode"] = {"value": 99}
+        vac = SharkVacuum.from_skegox(data)
+        assert vac.flow_mode is None
+        assert vac.water_flow == "normal"
 
 
 class TestDiscoveryDedup:

--- a/tests/test_shark_device.py
+++ b/tests/test_shark_device.py
@@ -123,6 +123,51 @@ class TestWaterFlow:
         assert vac.water_flow == "normal"
 
 
+class TestWaterFlowOverrideWhileDocked:
+    """Mirrors the fan_speed override: hardware reports eco while docked,
+    so the last user-set value should be substituted in the published
+    attributes, same as the existing fan_speed override for state."""
+
+    @pytest.fixture
+    def client(self, mock_config):
+        client = MqttClient(mock_config)
+        client._publish = AsyncMock()
+        return client
+
+    @pytest.mark.asyncio
+    async def test_no_override_uses_device_reported_value(self, client):
+        vac = make_vacuum(docked_status=1)
+        await client.publish_state(vac)
+        attrs_call = [
+            c for c in client._publish.call_args_list
+            if c.args[0].endswith("/attributes")
+        ][0]
+        assert attrs_call.args[1]["water_flow"] == "normal"  # no Flow_Mode set
+
+    @pytest.mark.asyncio
+    async def test_override_applied_while_docked(self, client):
+        vac = make_vacuum(docked_status=1)
+        client._water_flow_overrides[vac.dsn] = "max"
+        await client.publish_state(vac)
+        attrs_call = [
+            c for c in client._publish.call_args_list
+            if c.args[0].endswith("/attributes")
+        ][0]
+        assert attrs_call.args[1]["water_flow"] == "max"
+
+    @pytest.mark.asyncio
+    async def test_no_override_when_not_docked(self, client):
+        vac = make_vacuum(operating_mode=2, docked_status=0, charging_status=0)
+        client._water_flow_overrides[vac.dsn] = "max"
+        await client.publish_state(vac)
+        attrs_call = [
+            c for c in client._publish.call_args_list
+            if c.args[0].endswith("/attributes")
+        ][0]
+        # Not docked -> trust the device's own reported value, not the override
+        assert attrs_call.args[1]["water_flow"] == "normal"
+
+
 class TestDiscoveryDedup:
     @pytest.fixture
     def client(self, mock_config):

--- a/tests/test_water_flow_api.py
+++ b/tests/test_water_flow_api.py
@@ -1,0 +1,40 @@
+"""Tests for set_water_flow dispatch on skegox and ayla API backends."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.skegox_api import SkegoxApi
+
+
+class FakeConfig:
+    shark_region = "us"
+
+
+@pytest.mark.asyncio
+async def test_skegox_set_water_flow_max():
+    api = SkegoxApi.__new__(SkegoxApi)
+    api._household_id = "hh1"
+    api.set_desired_property = AsyncMock()
+    await api.set_water_flow("SND1", "max")
+    api.set_desired_property.assert_awaited_once_with("SND1", "Flow_Mode", 2)
+
+
+@pytest.mark.asyncio
+async def test_skegox_set_water_flow_eco():
+    api = SkegoxApi.__new__(SkegoxApi)
+    api._household_id = "hh1"
+    api.set_desired_property = AsyncMock()
+    await api.set_water_flow("SND1", "eco")
+    api.set_desired_property.assert_awaited_once_with("SND1", "Flow_Mode", 0)
+
+
+@pytest.mark.asyncio
+async def test_skegox_set_water_flow_unknown_noops():
+    api = SkegoxApi.__new__(SkegoxApi)
+    api._household_id = "hh1"
+    api.set_desired_property = AsyncMock()
+    await api.set_water_flow("SND1", "bogus")
+    api.set_desired_property.assert_not_awaited()


### PR DESCRIPTION
## Summary

- Adds control for the SharkClean app's independent **"Water Flow Level"** slider (eco/normal/max) on vac+mop combo models — separate from the existing vacuum Power Level control, and previously not exposed here at all.
- Property discovered via a `DEBUG`-level shadow dump on a real RV2820YEUS: the device shadow carries `Flow_Mode` alongside `Power_Mode`, using the identical `0/1/2` eco/normal/max scale.
- Implementation mirrors the existing `Power_Mode`/`fan_speed` code path 1:1 (constants, `SharkVacuum.flow_mode`/`water_flow` properties, `set_water_flow()` on both `SkegoxApi` and `AylaApi`, `CommandRouter` dispatch, and a new `select.<name>_water_flow` HA MQTT discovery entity with eco/normal/max options).
- `water_flow` is also included in the attributes payload for anyone who wants raw MQTT/automation access without the select entity.

## Testing

- 29/29 existing + new unit tests pass (7 new tests covering `flow_mode`/`water_flow` property parsing and `set_water_flow` dispatch on both API backends).
- Verified live against a real RV2820YEUS: confirmed `flow_mode` correctly reads `Flow_Mode=0` from the device shadow and maps to `"eco"`, matching `power_mode`'s parsing exactly.
- Verified the write path: `set_water_flow(snd, "max")` PATCHes successfully. As a control, ran the identical test against the existing, in-production `set_fan_speed("max")` — both show the robot reporting "eco" back while docked, which is the documented, known hardware quirk (`When docked, the device reports eco — use the user's last-set speed instead`), not a bug. Read/write parity with the trusted `Power_Mode` reference is exact.
- Not tested while actively mopping (would require kicking off a live clean cycle) — happy to do that verification too if useful before merge, or as a follow-up once merged.
- Not tested against vac-only models (no mop tank). `Flow_Mode` should simply be absent from their shadow, in which case `water_flow` defaults to `"normal"` and the select entity would just PATCH a property the device doesn't have — a no-op, per the same defensive pattern used elsewhere in this codebase (e.g. `has_areas_v3` detection).

## Test plan

- [x] `pytest tests/` — 29/29 passing
- [x] Live read verification against real RV2820YEUS
- [x] Live write verification (round-trip via SkegoxApi) with a control test against the known-good Power_Mode
- [ ] Live verification while actively mopping (not just docked) — optional, can follow up
