### PR TITLE
Fix browser auth navigation failures bypassing the circuit breaker

### DIFF
--- a/src/shark_auth.py
+++ b/src/shark_auth.py
@@ -129,8 +129,8 @@ class SharkAuth:
                 await self._refresh_auth0_token()
                 self._consecutive_failures = 0
                 return self._tokens.auth0_id_token  # type: ignore[return-value]
-            except SharkAuthError:
-                logger.warning("Auth0 refresh_token grant failed")
+            except SharkAuthError as e:
+                logger.warning("Auth0 refresh_token grant failed: %s", e)
 
         # Step 3: Try browser auth
         try:
@@ -255,14 +255,21 @@ class SharkAuth:
                 cdp.on("Network.requestWillBeSent", _on_cdp_request)
                 await cdp.send("Network.enable")
 
-                # Navigate to Auth0 authorize
-                await page.goto(authorize_url, wait_until="domcontentloaded")
-
                 auth_error: Exception | None = None
                 # Tracks how far the flow got, so a failure can report whether
-                # the email or the password was rejected.
-                auth_step = "email"
+                # navigation itself failed, or the email/password was rejected.
+                auth_step = "navigate"
                 try:
+                    # Navigate to Auth0 authorize. Kept inside this try (not
+                    # before it) so a navigation failure — e.g. the login
+                    # page not loading at all, as opposed to the Turnstile
+                    # checkbox getting stuck — still gets a screenshot and
+                    # becomes a SharkAuthError, so it properly trips the
+                    # circuit breaker instead of escaping as a raw
+                    # patchright/Playwright exception that bypasses backoff.
+                    await page.goto(authorize_url, wait_until="domcontentloaded")
+                    auth_step = "email"
+
                     # Fill email — Auth0 uses a multi-step flow
                     username_input = page.locator(
                         'input[name="username"], input[type="email"]'

--- a/tests/test_shark_auth.py
+++ b/tests/test_shark_auth.py
@@ -1,0 +1,83 @@
+"""Tests for SharkAuth error handling and circuit-breaker behavior."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.exc import SharkAuthError
+from src.shark_auth import SharkAuth
+
+
+def make_auth_config(tmp_path) -> MagicMock:
+    config = MagicMock()
+    config.shark_region = "us"
+    config.shark_username = "test@example.com"
+    config.shark_password = "hunter2"
+    config.token_dir = str(tmp_path)
+    config.log_level = "INFO"
+    return config
+
+
+class TestRefreshFailureLogging:
+    @pytest.mark.asyncio
+    async def test_refresh_failure_reason_is_logged(self, tmp_path, caplog):
+        auth = SharkAuth(make_auth_config(tmp_path))
+        auth._tokens = MagicMock(auth0_id_token=None, auth0_refresh_token="stale-token")
+        auth._refresh_auth0_token = AsyncMock(
+            side_effect=SharkAuthError("Auth0 refresh failed (400): invalid_grant expired")
+        )
+        auth._browser_authenticate = AsyncMock(side_effect=SharkAuthError("no browser"))
+
+        with caplog.at_level("WARNING"):
+            with pytest.raises(SharkAuthError):
+                await auth.ensure_authenticated()
+
+        assert any(
+            "invalid_grant" in record.message for record in caplog.records
+        ), "the actual Auth0 rejection reason should be logged, not swallowed"
+
+
+class TestBrowserAuthErrorHandling:
+    @pytest.mark.asyncio
+    async def test_navigation_failure_becomes_shark_auth_error(self, tmp_path):
+        """A page.goto() failure (e.g. login.sharkninja.com unreachable) must
+        raise SharkAuthError — not escape as a raw patchright/Playwright
+        exception — so it reaches ensure_authenticated()'s circuit breaker
+        instead of bypassing it and retry-hammering Auth0 every poll cycle.
+        """
+        auth = SharkAuth(make_auth_config(tmp_path))
+        auth._save_failure_screenshot = AsyncMock()
+        auth._extract_page_error = AsyncMock(return_value=None)
+
+        mock_page = AsyncMock()
+        mock_page.goto.side_effect = TimeoutError("Page.goto: Timeout 30000ms exceeded.")
+
+        mock_cdp = AsyncMock()
+        mock_cdp.on = MagicMock()  # synchronous event-registration call
+
+        mock_context = AsyncMock()
+        mock_context.new_page.return_value = mock_page
+        mock_context.new_cdp_session.return_value = mock_cdp
+
+        mock_browser = AsyncMock()
+        mock_browser.new_context.return_value = mock_context
+
+        mock_chromium = AsyncMock()
+        mock_chromium.launch.return_value = mock_browser
+
+        mock_playwright_obj = MagicMock()
+        mock_playwright_obj.chromium = mock_chromium
+
+        mock_playwright_cm = AsyncMock()
+        mock_playwright_cm.__aenter__.return_value = mock_playwright_obj
+        mock_playwright_cm.__aexit__.return_value = None
+
+        with patch("patchright.async_api.async_playwright", return_value=mock_playwright_cm):
+            with pytest.raises(SharkAuthError):
+                await auth._browser_authenticate()
+
+        # Navigation failures should still get a diagnostic screenshot,
+        # same as email/password failures do.
+        auth._save_failure_screenshot.assert_awaited_once()


### PR DESCRIPTION
page.goto() to the Auth0 login page sat outside the try/except that converts failures into SharkAuthError, so a navigation timeout (e.g. login.sharkninja.com unreachable) escaped ensure_authenticated() uncaught as a raw patchright exception. That skipped both the diagnostic screenshot/page-error scrape and, more importantly, the circuit breaker's consecutive-failure tracking and backoff — letting the poll loop retry-hammer Auth0/Cloudflare every cycle instead of backing off.

Also stop swallowing the actual Auth0 rejection reason on a failed refresh_token grant; the log line previously just said "grant failed" with no indication of why (invalid_grant, rate limited, revoked, etc).

Found while diagnosing a real add-on outage: a dead refresh token combined with page.goto() timeouts on every retry, which the old code couldn't properly back off from.