### PR TITLE
Map Operating_Mode 6 (dry room clean) to the cleaning state, and log unmapped modes

### DIFF
--- a/src/const.py
+++ b/src/const.py
@@ -59,7 +59,8 @@ class OperatingMode(IntEnum):
     START = 2
     RETURN = 3
     EXPLORE = 4
-    # Modes 5-6 unknown
+    # Mode 5 still unknown
+    ROOM_CLEAN = 6  # room/area clean (observed on RV2820ZECA)
     MOP = 7
     VACUUM_AND_MOP = 8
 
@@ -79,6 +80,7 @@ OPERATING_MODE_TO_HA_STATE: dict[OperatingMode, str] = {
     OperatingMode.START: "cleaning",
     OperatingMode.RETURN: "returning",
     OperatingMode.EXPLORE: "cleaning",
+    OperatingMode.ROOM_CLEAN: "cleaning",
     OperatingMode.MOP: "cleaning",
     OperatingMode.VACUUM_AND_MOP: "cleaning",
 }

--- a/src/shark_device.py
+++ b/src/shark_device.py
@@ -186,6 +186,24 @@ class SharkVacuum:
         try:
             return OperatingMode(val)
         except ValueError:
+            # -1 means the property was ABSENT; anything else means it
+            # was present but out-of-enum. Silently returning None here
+            # makes ha_state report `idle`, which is indistinguishable
+            # from a genuinely idle robot.
+            logger.warning(
+                "UNMAPPED_OPERATING_MODE coerced=%r present=%s raw=%r | Operating_Mode_Ex=%r robot_status=%r DockedStatus=%r Charging_Status=%r CleanComplete=%r MissionComplete=%r RunTimeCycle=%r Error_Code=%r",
+                val,
+                PROP_GET_OPERATING_MODE in self._properties,
+                self._properties.get(PROP_GET_OPERATING_MODE, "<ABSENT>"),
+                self._properties.get("GET_Operating_Mode_Ex", "<ABSENT>"),
+                self._properties.get("GET_robot_status", "<ABSENT>"),
+                self._properties.get("GET_DockedStatus", "<ABSENT>"),
+                self._properties.get("GET_Charging_Status", "<ABSENT>"),
+                self._properties.get("GET_CleanComplete", "<ABSENT>"),
+                self._properties.get("GET_MissionComplete", "<ABSENT>"),
+                self._properties.get("GET_RunTimeCycle", "<ABSENT>"),
+                self._properties.get("GET_Error_Code", "<ABSENT>"),
+            )
             return None
 
     @property


### PR DESCRIPTION
## Summary

A **dry room-by-room clean** reports `Operating_Mode = 6`, which has no entry in
the `OperatingMode` enum. `OperatingMode(6)` raises `ValueError`,
`operating_mode` returns `None`, and `ha_state` falls through to `"idle"` — so
**a dry room clean shows as `idle` in Home Assistant for its entire duration**,
indistinguishable from a robot sitting on the dock.

This is the path the generated per-room `clean_room` buttons use, since
`mqtt_client.py` sends `clean_type="dry"` for them.

Two commits:

1. **`Map Operating_Mode 6 (room clean) to the cleaning state`** — the fix.
2. **`Log unmapped Operating_Mode values instead of silently reporting idle`** —
   diagnostics. Independently useful, and the only reason mode 6 was
   identifiable.

## Scope — only one case is affected

Tested each combination on hardware:

| Clean | Operating_Mode | Before | After |
|---|---|---|---|
| Whole-house, dry | 2 (`START`) | ✅ `cleaning` | ✅ `cleaning` |
| Whole-house, wet | 7 (`MOP`) | ✅ `cleaning` | ✅ `cleaning` |
| **Room, dry** | **6** | ❌ **`idle`** | ✅ **`cleaning`** |
| Room, wet | 7 (`MOP`) | ✅ `cleaning` | ✅ `cleaning` |

So `Operating_Mode` encodes *what the robot is doing* (vacuum vs mop) rather than
*scope* (room vs whole-house) — except for the dry room clean, which gets its own
value. Wet room cleans were never broken.

## How it presented

The dashboard reported the robot as docked and idle while it was demonstrably
vacuuming. What made it hard to spot is that `idle` is a *plausible* answer —
nothing errored, nothing was logged, and the robot genuinely had been idle a
minute earlier. It was only caught by noticing a 10–20% battery drain across a
window in which Home Assistant claimed the robot had done nothing.

## Evidence

Observed consistently during active dry room cleans, poll interval 20s, robot
visually confirmed to be vacuuming:

```
UNMAPPED_OPERATING_MODE coerced=6 present=True raw=6
  | Operating_Mode_Ex='{"operating_mode":6,"sys_st":6}'
    robot_status=0 DockedStatus=False Charging_Status=False
    CleanComplete=False MissionComplete=False RunTimeCycle=0 Error_Code=0
```

`Operating_Mode_Ex` corroborates `Operating_Mode` independently, so this isn't a
parsing artefact of one field.

**Before** — three separate dry room cleans, 15–23 minutes each:

```
docked -> idle (entire run) -> returning -> docked
```

`state` stayed `idle` and `operating_mode` stayed `unknown` throughout, while
battery fell 100% → 90% and 100% → 80%.

**After** — same robot, same room button, same pinned image, only this change:

```
state          = cleaning
operating_mode = ROOM_CLEAN
is_docked      = False
```

The `UNMAPPED_OPERATING_MODE` warning also stopped firing — a useful negative
control: the diagnostic went quiet because the value became recognised, not
because it stopped looking.

## Regression check

Mode mapping compared exhaustively against pristine `v1.5.4` for values 0–8.
Only mode 6 differs; 0, 1, 2, 3, 4, 5, 7 and 8 are unchanged.

## Mode 5 is deliberately left unmapped

The enum comment reads `# Modes 5-6 unknown`. This PR resolves 6 only.

I hypothesised that 5 might be a wet room clean, and **tested it: it is not.** A
wet room clean reports 7 (`MOP`). Mode 5 was never observed here, so guessing at
it would be speculation — recording the negative result so nobody else has to run
the same experiment.

## A hypothesis that turned out to be wrong

Worth recording in case someone follows the same reasoning. I first assumed the
cause was the asymmetry in `clean_rooms()`, where the legacy branch sets
`Operating_Mode = 2` after writing the areas payload and the v3 branch does not.

That is **not** the cause. Setting `Operating_Mode = 2` on the v3 path was tested
on hardware: the robot ignored it, continued reporting mode 6, and continued
cleaning only the selected room. `clean_rooms()` is therefore untouched here. The
asymmetry may still be worth a look, but it is not this bug, and writing mode 2
during a room clean risks converting a single-room job into a whole-house one on
models I can't test.

## Note on the logging commit

The warning fires on every poll while a mode is unmapped, which on a long run at
a short poll interval could be noisy. Happy to throttle it to once per distinct
value per session, or drop it to `debug` — say the word and I'll amend.

## Caveats

- Observed on a **single unit** (RV2820ZECA, skegox backend). I can't tell
  whether mode 6 is used consistently across the range, so it's possible other
  models report a different value for the same operation. The logging commit is
  what makes that answerable for the next reporter.
- Branch is based on `v1.5.4`.

Account identifiers, serial numbers, household and floor IDs, and room names have
been redacted from all output above.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
