### PR TITLE
Dump shadow values at DEBUG, gate the water flow entity, explain MQTT auth failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,29 @@ The refresh token is long-lived, so once you have a working `shark2mqtt_tokens.j
 
 Repeated failed attempts can temporarily lock your SharkNinja account, so if the challenge is failing, stop the retry loop (set restart policy to `no` or use `--auth-once`) before trying again.
 
+### If login says "Your account has been locked"
+
+This one is a different animal from the Turnstile problem above, and the message is misleading. The signature is:
+
+- The automated login fails with *"Your account has been locked. Please check your email to log in"*.
+- No lockout email ever arrives (check spam).
+- Logging into [login.sharkninja.com](https://login.sharkninja.com) by hand, in a normal browser, with the same credentials, works immediately.
+- Resetting your password changes nothing -- you get a byte-identical failure screenshot.
+
+That combination means Auth0's risk-based bot detection has flagged the *automated sign-in pattern*, not your account. There is nothing wrong with your credentials and nothing to unlock. Thanks to @dewbot6 for diagnosing this in [#38](https://github.com/CamSoper/shark2mqtt/issues/38).
+
+**What to do:** stop the retry loop and wait it out. Set the restart policy to `no` (or stop the add-on) and leave it alone for several hours -- overnight is a reasonable first attempt. Retrying against an already-flagged pattern tends to extend the block rather than clear it.
+
+While you're waiting, it's worth confirming this isn't just a dead refresh token, which produces a similar "vacuum went unavailable but the app works fine" symptom. Look for this in the logs:
+
+```
+Auth0 refresh_token grant failed: <reason>
+```
+
+The reason is logged as of v1.5.5. An `invalid_grant` there means the saved token was revoked (a password change will do it), in which case you need a fresh browser login rather than a wait -- see the token bootstrap steps above.
+
+If you hit this, please add what you find to [#38](https://github.com/CamSoper/shark2mqtt/issues/38), especially how long the block took to clear. How long the cooldown actually runs is still an open question.
+
 ## Home Assistant Entities
 
 Each vacuum is automatically discovered by Home Assistant with the following entities:
@@ -124,8 +147,9 @@ Each vacuum is automatically discovered by Home Assistant with the following ent
 | `binary_sensor.<name>_error` | Binary Sensor | Error state (on when error present) |
 | `button.<name>_clean_<room>` | Button | One-tap room cleaning (one per room) |
 | `select.<name>_clean_mode` | Select | Normal or Matrix (double-pass) cleaning mode |
+| `select.<name>_water_flow` | Select | Mop water flow level (vac+mop models only) |
 
-Room buttons and the clean mode select appear automatically when room data is available from the Shark cloud.
+Room buttons and the clean mode select appear automatically when room data is available from the Shark cloud. The water flow select appears only on models that report `Flow_Mode` -- i.e. those with a mop tank -- so vacuum-only models won't get a control their hardware ignores.
 
 An error device trigger fires when a new error is detected, usable in HA automations.
 
@@ -206,6 +230,24 @@ data:
 ## Contributing
 
 This project scratches a personal itch — I'm sharing it in case it helps others, not looking to take on a maintenance burden. If something doesn't work for you, please submit a **pull request** rather than an issue. I only own two vacuum models, so I can't test or troubleshoot devices I don't have. PRs with fixes or support for additional models are welcome; issues requesting changes are likely to be closed.
+
+### Capturing a shadow dump
+
+Nearly every model-specific fix here started as a shadow dump from someone else's hardware, so if you're reporting or fixing behaviour on a model I don't own, this is the single most useful thing to include.
+
+Set `LOG_LEVEL=debug` and look for these lines, logged once per poll cycle per device:
+
+```
+Shadow values for <name>: {...}        # skegox backend
+Ayla property values for <name>: {...} # Ayla backend
+```
+
+That's every property the device reports, **with its value**. Long blobs (map URLs, error logs) are truncated so the line stays readable.
+
+Two things worth knowing:
+
+- Some properties only hold their interesting value while a clean is actively assigned. `AreasToClean_V3`, for example, reverts to `*` once the robot docks, so start the clean and capture within the first couple of poll cycles. Setting `POLL_INTERVAL_ACTIVE=5` helps.
+- Dumps contain your DSN, floor IDs, and room names. Redact them before posting.
 
 ## Acknowledgements
 

--- a/src/ayla_api.py
+++ b/src/ayla_api.py
@@ -432,9 +432,21 @@ class AylaApi:
                         vacuum._properties.get("GET_Robot_Room_List"),
                         vacuum.floor_id, vacuum.rooms,
                     )
+                    def _short(x: Any) -> Any:
+                        # Map URLs and error logs are long; keep one
+                        # device's dump to one readable line.
+                        text = repr(x)
+                        if len(text) <= 240:
+                            return x
+                        return f"{text[:240]}...<truncated, {len(text)} chars>"
+
+                    # Names alone can't answer "what was this set to?", which
+                    # is the question every model-specific bug report needs
+                    # answered. See issue #27.
                     logger.debug(
-                        "Ayla property names for %s: %s",
-                        vacuum.product_name, sorted_names,
+                        "Ayla property values for %s: %s",
+                        vacuum.product_name,
+                        {k: _short(vacuum._properties.get(k)) for k in sorted_names},
                     )
                     logger.debug(
                         "Ayla room/area/zone/map/floor properties for %s: %s",

--- a/src/main.py
+++ b/src/main.py
@@ -9,6 +9,8 @@ import signal
 
 from typing import Any
 
+import aiomqtt
+
 from .ayla_api import AylaApi, MardData, debug_dump_mard_structure, parse_mard
 from .config import Settings
 from .exc import SharkAuthError
@@ -18,6 +20,22 @@ from .shark_device import SharkVacuum
 from .skegox_api import SkegoxApi
 
 logger = logging.getLogger("shark2mqtt")
+
+# Broker CONNACK codes that mean "your credentials were refused" rather than
+# "the broker is unreachable". 4/5 are MQTT 3.1.1 CONNACK codes; 134/135 are
+# the MQTT 5 reason codes for the same two conditions.
+_MQTT_AUTH_RCS = frozenset({4, 5, 134, 135})
+
+
+def _is_mqtt_auth_failure(err: aiomqtt.MqttError) -> bool:
+    """Whether an MQTT error is a credential rejection.
+
+    aiomqtt carries the code on `rc`, as a bare int on MQTT 3.1.1 and a
+    paho ReasonCode (which holds the number in `.value`) on MQTT 5, so the
+    number has to be dug out rather than matched in the message text.
+    """
+    rc = getattr(err, "rc", None)
+    return getattr(rc, "value", rc) in _MQTT_AUTH_RCS
 
 
 class CommandRouter:
@@ -334,6 +352,24 @@ async def run(config: Settings) -> None:
 
     except (SystemExit, KeyboardInterrupt):
         logger.info("Shutting down gracefully")
+    except aiomqtt.MqttError as e:
+        # A broker rejection used to surface as a bare aiomqtt traceback,
+        # which reads like a shark2mqtt crash even though authentication
+        # to SharkNinja succeeded and only the MQTT hop failed (issue #40).
+        logger.error(
+            "MQTT broker error (%s:%s): %s",
+            config.mqtt_host, config.mqtt_port, e,
+        )
+        if _is_mqtt_auth_failure(e):
+            logger.error(
+                "The broker rejected the connection as unauthorized. "
+                "MQTT_USERNAME is %s. If the broker requires a login, "
+                "anonymous connections are refused — set MQTT_USERNAME and "
+                "MQTT_PASSWORD to match a broker account.",
+                f"set to {config.mqtt_username!r}"
+                if config.mqtt_username else "not set (connecting anonymously)",
+            )
+        raise SystemExit(1) from e
     finally:
         await api.close()
         await ayla_api.close()

--- a/src/mqtt_client.py
+++ b/src/mqtt_client.py
@@ -135,6 +135,15 @@ class MqttClient:
                 },
                 retain=True,
             )
+        else:
+            # Discovery configs are retained, so simply not publishing one
+            # leaves any previously-published entity sitting in HA forever.
+            # An empty retained payload is autodiscovery's delete.
+            await self._publish(
+                f"{HA_DISCOVERY_PREFIX}/select/{uid}_water_flow/config",
+                "",
+                retain=True,
+            )
 
         # Battery sensor
         await self._publish(

--- a/src/mqtt_client.py
+++ b/src/mqtt_client.py
@@ -76,7 +76,11 @@ class MqttClient:
         # is pure noise (issue #29). Skip unless something that feeds the
         # configs (device info or room list) actually changed.
         sig = json.dumps(
-            {"device": device.device_info, "rooms": device.rooms},
+            {
+                "device": device.device_info,
+                "rooms": device.rooms,
+                "has_flow_mode": device.has_flow_mode,
+            },
             sort_keys=True,
         )
         if self._discovery_sigs.get(dsn) == sig:
@@ -109,27 +113,28 @@ class MqttClient:
             retain=True,
         )
 
-        # Water flow level select (mop water flow — vac+mop combo models
-        # only; harmless no-op on the device for vac-only models since we
-        # simply won't have a truthy water_flow attribute to key off of).
-        await self._publish(
-            f"{HA_DISCOVERY_PREFIX}/select/{uid}_water_flow/config",
-            {
-                "name": "Water Flow Level",
-                "unique_id": f"{uid}_water_flow",
-                "object_id": f"{slug}_water_flow",
-                "command_topic": f"{self._prefix}/{dsn}/set_water_flow",
-                "state_topic": f"{self._prefix}/{dsn}/attributes",
-                "value_template": "{{ value_json.water_flow }}",
-                "options": ["eco", "normal", "max"],
-                "icon": "mdi:water-percent",
-                "availability_topic": f"{self._prefix}/{dsn}/available",
-                "payload_available": "online",
-                "payload_not_available": "offline",
-                "device": device.device_info,
-            },
-            retain=True,
-        )
+        # Water flow level select — only for models that actually have a mop
+        # tank. Publishing it unconditionally gave vac-only owners a control
+        # that looked real but wrote a property their hardware ignores.
+        if device.has_flow_mode:
+            await self._publish(
+                f"{HA_DISCOVERY_PREFIX}/select/{uid}_water_flow/config",
+                {
+                    "name": "Water Flow Level",
+                    "unique_id": f"{uid}_water_flow",
+                    "object_id": f"{slug}_water_flow",
+                    "command_topic": f"{self._prefix}/{dsn}/set_water_flow",
+                    "state_topic": f"{self._prefix}/{dsn}/attributes",
+                    "value_template": "{{ value_json.water_flow }}",
+                    "options": ["eco", "normal", "max"],
+                    "icon": "mdi:water-percent",
+                    "availability_topic": f"{self._prefix}/{dsn}/available",
+                    "payload_available": "online",
+                    "payload_not_available": "offline",
+                    "device": device.device_info,
+                },
+                retain=True,
+            )
 
         # Battery sensor
         await self._publish(
@@ -445,8 +450,10 @@ class MqttClient:
             state_payload["fan_speed"] = self._fan_speed_overrides[dsn]
 
         attributes_payload = device.to_attributes_payload()
-        # Same dock-reports-eco quirk applies to water_flow (mop flow level).
-        if device.is_docked and dsn in self._water_flow_overrides:
+        # Same dock-reports-eco quirk applies to water_flow (mop flow level),
+        # but only reinstate the override on models that report the property
+        # at all — otherwise it reintroduces water_flow on vac-only models.
+        if device.has_flow_mode and device.is_docked and dsn in self._water_flow_overrides:
             attributes_payload["water_flow"] = self._water_flow_overrides[dsn]
 
         await self._publish(f"{self._prefix}/{dsn}/state", state_payload, retain=True)

--- a/src/shark_device.py
+++ b/src/shark_device.py
@@ -142,6 +142,16 @@ class SharkVacuum:
             raw_atc = reported.get("Areas_To_Clean", {})
             def _val(x: Any) -> Any:
                 return x.get("value", x) if isinstance(x, dict) else x
+
+            def _short(x: Any) -> Any:
+                # A few properties carry map URLs, error logs, or whole JSON
+                # blobs. Truncate them so one device's dump stays one
+                # readable line instead of scrolling a terminal off-screen.
+                text = repr(x)
+                if len(text) <= 240:
+                    return x
+                return f"{text[:240]}...<truncated, {len(text)} chars>"
+
             prop_names = sorted(reported.keys())
             hint_keywords = ("room", "area", "zone", "map", "floor")
             hint_props = {
@@ -157,8 +167,15 @@ class SharkVacuum:
                 _val(raw_room_list), _val(raw_v3), _val(raw_v2),
                 _val(raw_atc), vac.floor_id, vac.rooms,
             )
+            # Every reported property with its value. Logging only the names
+            # (as this did originally) meant anyone reporting model-specific
+            # behaviour could confirm a property existed but never say what
+            # it was set to, which stalled issue #27. Values are what make a
+            # bug report actionable, so dump them.
             logger.debug(
-                "Shadow property names for %s: %s", name, prop_names,
+                "Shadow values for %s: %s",
+                name,
+                {k: _short(_val(reported[k])) for k in prop_names},
             )
             logger.debug(
                 "Room/area/zone/map/floor properties for %s: %s",
@@ -294,6 +311,16 @@ class SharkVacuum:
         return POWER_MODE_NAMES.get(mode, "normal")
 
     @property
+    def has_flow_mode(self) -> bool:
+        """Whether this model has a mop tank with a water flow setting.
+
+        Only vac+mop combo models carry Flow_Mode in their shadow. Both
+        backends land properties in `_properties` under the `GET_` name,
+        so this works for skegox and Ayla alike.
+        """
+        return PROP_GET_FLOW_MODE in self._properties
+
+    @property
     def rssi(self) -> int:
         # Some models report RSSI as positive, others as negative dBm.
         # Real WiFi RSSI is always ≤ 0 dBm, so normalize to negative.
@@ -389,8 +416,11 @@ class SharkVacuum:
             "run_time_cumulative": self.run_time_cumulative,
             "replace_battery": self.replace_battery,
             "recommend_rest_and_recharge": self.recommend_rest_and_recharge,
-            "water_flow": self.water_flow,
         }
+        # Vac-only models have no mop tank, so reporting a water flow level
+        # for them would be inventing a setting the hardware doesn't have.
+        if self.has_flow_mode:
+            attrs["water_flow"] = self.water_flow
         if self.rooms:
             attrs["rooms"] = self.rooms
             attrs["floor_id"] = self.floor_id

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,102 @@
+"""Tests for the diagnostics that make user bug reports actionable.
+
+Two separate incidents motivated these: issue #40 (a broker credential
+rejection surfacing as a raw aiomqtt traceback that read like a crash in
+shark2mqtt) and issue #27 (a reporter who could see which shadow
+properties existed but never what they were set to).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+from aiomqtt.exceptions import MqttConnectError, MqttError
+
+from src.main import _is_mqtt_auth_failure
+from src.shark_device import SharkVacuum
+
+from .conftest import make_skegox_device
+
+
+class TestMqttAuthFailureDetection:
+    """The credential hint must key off the numeric code, not message text.
+
+    MQTT 3.1.1 reports a bare CONNACK int; MQTT 5 reports a paho ReasonCode
+    whose number lives in `.value`. The stringified message differs between
+    them (135 renders as "Unknown error" when built from a bare int), so
+    substring matching on the message is not reliable.
+    """
+
+    @pytest.mark.parametrize("rc", [4, 5])
+    def test_v311_credential_codes(self, rc):
+        assert _is_mqtt_auth_failure(MqttConnectError(rc)) is True
+
+    @pytest.mark.parametrize("rc", [134, 135])
+    def test_v5_reason_codes(self, rc):
+        from paho.mqtt.packettypes import PacketTypes
+        from paho.mqtt.reasoncodes import ReasonCode
+
+        err = MqttConnectError(ReasonCode(PacketTypes.CONNACK, identifier=rc))
+        assert _is_mqtt_auth_failure(err) is True
+
+    def test_matches_the_error_reported_in_issue_40(self):
+        from paho.mqtt.packettypes import PacketTypes
+        from paho.mqtt.reasoncodes import ReasonCode
+
+        err = MqttConnectError(ReasonCode(PacketTypes.CONNACK, identifier=135))
+        assert str(err) == "[code:135] Not authorized"
+        assert _is_mqtt_auth_failure(err) is True
+
+    @pytest.mark.parametrize("rc", [1, 2, 3])
+    def test_non_credential_refusals(self, rc):
+        # Wrong protocol version / bad client id / server unavailable are
+        # real failures, but telling the user to check their password
+        # would send them down the wrong path.
+        assert _is_mqtt_auth_failure(MqttConnectError(rc)) is False
+
+    def test_plain_mqtt_error_has_no_code(self):
+        assert _is_mqtt_auth_failure(MqttError("broker went away")) is False
+
+
+class TestShadowValueDump:
+    """Issue #27: names alone can't answer "what was it set to?"."""
+
+    def _dump(self, caplog) -> str:
+        return "\n".join(
+            r.message for r in caplog.records if "Shadow values" in r.message
+        )
+
+    def test_dump_includes_property_values(self, caplog):
+        data = make_skegox_device()
+        data["shadow"]["properties"]["reported"]["SmartMopEnabled"] = {"value": 1}
+        data["shadow"]["properties"]["reported"]["PadPriming"] = {"value": 0}
+
+        with caplog.at_level(logging.DEBUG, logger="src.shark_device"):
+            SharkVacuum.from_skegox(data)
+
+        dump = self._dump(caplog)
+        assert "SmartMopEnabled" in dump
+        assert "PadPriming" in dump
+        # The whole point: the value, not just the name.
+        assert "'SmartMopEnabled': 1" in dump
+        assert "'PadPriming': 0" in dump
+
+    def test_long_values_are_truncated(self, caplog):
+        data = make_skegox_device()
+        data["shadow"]["properties"]["reported"]["JSON_Data_Log"] = {
+            "value": "x" * 5000
+        }
+
+        with caplog.at_level(logging.DEBUG, logger="src.shark_device"):
+            SharkVacuum.from_skegox(data)
+
+        dump = self._dump(caplog)
+        assert "truncated" in dump
+        # A 5000-char blob must not land in the log in full.
+        assert "x" * 500 not in dump
+
+    def test_nothing_dumped_above_debug(self, caplog):
+        with caplog.at_level(logging.INFO, logger="src.shark_device"):
+            SharkVacuum.from_skegox(make_skegox_device())
+        assert self._dump(caplog) == ""

--- a/tests/test_shark_device.py
+++ b/tests/test_shark_device.py
@@ -24,6 +24,21 @@ def make_vacuum(
     return SharkVacuum.from_skegox(data)
 
 
+def make_mop_vacuum(
+    flow_mode: int = 1,
+    operating_mode: int = 0,
+    docked_status: int = 1,
+    charging_status: int = 0,
+) -> SharkVacuum:
+    """A vac+mop combo model — i.e. one whose shadow carries Flow_Mode."""
+    data = make_skegox_device(operating_mode=operating_mode)
+    reported = data["shadow"]["properties"]["reported"]
+    reported["DockedStatus"]["value"] = docked_status
+    reported["Charging_Status"]["value"] = charging_status
+    reported["Flow_Mode"] = {"value": flow_mode}
+    return SharkVacuum.from_skegox(data)
+
+
 class TestDockedState:
     def test_docked_status_docked(self):
         vac = make_vacuum(operating_mode=0, docked_status=1)
@@ -89,10 +104,12 @@ class TestDockAndMaintenanceProperties:
             "is_evacuating", "evacuate_state", "evacuate_resume_status",
             "dock_error_code", "dock_knob_status", "warning_code",
             "extended_error_code", "run_time_cumulative", "replace_battery",
-            "recommend_rest_and_recharge", "water_flow",
+            "recommend_rest_and_recharge",
         ):
             assert key in attrs
         assert "schedule" not in attrs  # omitted when empty
+        # No Flow_Mode in this shadow, so no mop tank to report a level for
+        assert "water_flow" not in attrs
 
 
 class TestWaterFlow:
@@ -123,6 +140,42 @@ class TestWaterFlow:
         assert vac.water_flow == "normal"
 
 
+class TestFlowModeCapability:
+    """Vac-only models must not advertise a mop control they can't honour."""
+
+    def test_absent_flow_mode_is_not_a_capability(self):
+        assert make_vacuum().has_flow_mode is False
+
+    def test_present_flow_mode_is_a_capability(self):
+        assert make_mop_vacuum(flow_mode=1).has_flow_mode is True
+
+    def test_capability_holds_even_for_out_of_range_values(self):
+        # The property exists, so the hardware has a tank; the level just
+        # didn't parse. Still a mop model.
+        vac = make_mop_vacuum(flow_mode=99)
+        assert vac.has_flow_mode is True
+        assert vac.water_flow == "normal"
+
+    def test_attributes_include_water_flow_for_mop_models(self):
+        assert "water_flow" in make_mop_vacuum(flow_mode=2).to_attributes_payload()
+
+    @pytest.mark.asyncio
+    async def test_discovery_skips_select_for_vac_only(self, mock_config):
+        client = MqttClient(mock_config)
+        client._publish = AsyncMock()
+        await client.publish_discovery(make_vacuum())
+        topics = [c.args[0] for c in client._publish.call_args_list]
+        assert not any("_water_flow/config" in t for t in topics)
+
+    @pytest.mark.asyncio
+    async def test_discovery_publishes_select_for_mop_models(self, mock_config):
+        client = MqttClient(mock_config)
+        client._publish = AsyncMock()
+        await client.publish_discovery(make_mop_vacuum(flow_mode=1))
+        topics = [c.args[0] for c in client._publish.call_args_list]
+        assert any("_water_flow/config" in t for t in topics)
+
+
 class TestWaterFlowOverrideWhileDocked:
     """Mirrors the fan_speed override: hardware reports eco while docked,
     so the last user-set value should be substituted in the published
@@ -134,38 +187,44 @@ class TestWaterFlowOverrideWhileDocked:
         client._publish = AsyncMock()
         return client
 
-    @pytest.mark.asyncio
-    async def test_no_override_uses_device_reported_value(self, client):
-        vac = make_vacuum(docked_status=1)
-        await client.publish_state(vac)
-        attrs_call = [
+    @staticmethod
+    def _attrs(client):
+        return [
             c for c in client._publish.call_args_list
             if c.args[0].endswith("/attributes")
-        ][0]
-        assert attrs_call.args[1]["water_flow"] == "normal"  # no Flow_Mode set
+        ][0].args[1]
+
+    @pytest.mark.asyncio
+    async def test_no_override_uses_device_reported_value(self, client):
+        vac = make_mop_vacuum(flow_mode=1, docked_status=1)
+        await client.publish_state(vac)
+        assert self._attrs(client)["water_flow"] == "normal"
 
     @pytest.mark.asyncio
     async def test_override_applied_while_docked(self, client):
-        vac = make_vacuum(docked_status=1)
+        vac = make_mop_vacuum(flow_mode=0, docked_status=1)
         client._water_flow_overrides[vac.dsn] = "max"
         await client.publish_state(vac)
-        attrs_call = [
-            c for c in client._publish.call_args_list
-            if c.args[0].endswith("/attributes")
-        ][0]
-        assert attrs_call.args[1]["water_flow"] == "max"
+        assert self._attrs(client)["water_flow"] == "max"
 
     @pytest.mark.asyncio
     async def test_no_override_when_not_docked(self, client):
-        vac = make_vacuum(operating_mode=2, docked_status=0, charging_status=0)
+        vac = make_mop_vacuum(
+            flow_mode=1, operating_mode=2, docked_status=0, charging_status=0
+        )
         client._water_flow_overrides[vac.dsn] = "max"
         await client.publish_state(vac)
-        attrs_call = [
-            c for c in client._publish.call_args_list
-            if c.args[0].endswith("/attributes")
-        ][0]
         # Not docked -> trust the device's own reported value, not the override
-        assert attrs_call.args[1]["water_flow"] == "normal"
+        assert self._attrs(client)["water_flow"] == "normal"
+
+    @pytest.mark.asyncio
+    async def test_override_never_resurrects_water_flow_on_vac_only(self, client):
+        # A stale override must not put the attribute back on a model that
+        # has no mop tank.
+        vac = make_vacuum(docked_status=1)
+        client._water_flow_overrides[vac.dsn] = "max"
+        await client.publish_state(vac)
+        assert "water_flow" not in self._attrs(client)
 
 
 class TestDiscoveryDedup:

--- a/tests/test_shark_device.py
+++ b/tests/test_shark_device.py
@@ -160,12 +160,20 @@ class TestFlowModeCapability:
         assert "water_flow" in make_mop_vacuum(flow_mode=2).to_attributes_payload()
 
     @pytest.mark.asyncio
-    async def test_discovery_skips_select_for_vac_only(self, mock_config):
+    async def test_discovery_retracts_select_for_vac_only(self, mock_config):
+        # Not publishing isn't enough — discovery configs are retained, so a
+        # config published by an earlier version would linger in HA. The
+        # empty payload is autodiscovery's delete.
         client = MqttClient(mock_config)
         client._publish = AsyncMock()
         await client.publish_discovery(make_vacuum())
-        topics = [c.args[0] for c in client._publish.call_args_list]
-        assert not any("_water_flow/config" in t for t in topics)
+        water_flow = [
+            c for c in client._publish.call_args_list
+            if "_water_flow/config" in c.args[0]
+        ]
+        assert len(water_flow) == 1
+        assert water_flow[0].args[1] == ""
+        assert water_flow[0].kwargs["retain"] is True
 
     @pytest.mark.asyncio
     async def test_discovery_publishes_select_for_mop_models(self, mock_config):


### PR DESCRIPTION
Follow-ups from triaging the open issues. Three unrelated fixes, all about surfacing what's actually happening.

## Shadow dumps now log values, not just names (#27)

The skegox and Ayla debug dumps logged property *names* only. That meant anyone reporting model-specific behaviour could confirm a property existed but never say what it was set to -- which is exactly where #27 stalled. @Shadinss had DEBUG logging on, a 5s poll interval, and still couldn't answer "what is `Operating_Mode` during a mop run?" because the values were never printed.

Both backends now dump every reported property with its value:

```
Shadow values for Sharpedo: {'Charging_Status': 0, 'Flow_Mode': 2, 'MopPlateAttached': 1,
 'Operating_Mode': 7, 'PadPriming': 0, 'SmartMopEnabled': 1, 'wet_clean_status': 3, ...}
```

Long values (map URLs, JSON data logs, error logs) truncate at 240 chars with a length marker, so one device's dump stays one readable line instead of dropping a 90 KB blob into the log.

## Water flow select is gated on the device having a mop tank

#36 published the `select.<name>_water_flow` entity for every device. Vacuum-only models have no `Flow_Mode` in their shadow, so they got a control that looked real but PATCHed a property the hardware ignores -- and `water_flow: "normal"` in their attributes, reporting a setting that doesn't exist.

Now gated on `Flow_Mode` being present, using the same capability-detection pattern as `has_areas_v3`. `has_flow_mode` reads from `_properties`, so it works identically on both backends. Also added to the discovery signature, so a device that starts reporting `Flow_Mode` gets the entity without needing a restart.

Nothing to clean up for existing users -- this shipped to `latest` but was never in a tagged release.

## MQTT credential rejections read like a crash (#40)

A broker rejection escaped as a raw `aiomqtt` traceback, which looked like shark2mqtt falling over even though auth to SharkNinja had fully succeeded and only the MQTT hop failed. Now:

```
[ERROR] MQTT broker error (core-mosquitto:1883): [code:135] Not authorized
[ERROR] The broker rejected the connection as unauthorized. MQTT_USERNAME is not set
        (connecting anonymously). If the broker requires a login, anonymous connections
        are refused -- set MQTT_USERNAME and MQTT_PASSWORD to match a broker account.
```

Detection uses the numeric code, not the message text. MQTT 3.1.1 sends a bare CONNACK int (4/5) while MQTT 5 sends a paho `ReasonCode` (134/135) whose number lives in `.value` -- and the two stringify differently, so substring matching on "not authorized" would miss the case that actually gets reported.

## Docs

- The Auth0 "Your account has been locked" failure mode from #38: what the signature looks like, why it's bot detection rather than a real lock, and to wait it out rather than retry. Credit to @dewbot6.
- How to capture a shadow dump worth posting, including the `AreasToClean_V3`-reverts-to-`*` trap and a reminder to redact DSNs.
- The water flow entity, which #36 added but didn't document.

## Testing

`pytest tests/` -- 53 passing, up from 34. New coverage for the flow mode capability gate (including that a stale override can't resurrect `water_flow` on a vac-only model), the auth-code detection across both MQTT protocol versions, and the shadow dump's values/truncation/log-level behaviour.

One test asserts the exact string from #40's traceback (`[code:135] Not authorized`) so the detection stays pinned to a real reported failure rather than my reading of the paho source.