### PR TITLE
Add Wet/Dry clean modes and Deep button; gate Water Flow on MopPlateAttached

### DIFF
--- a/src/ayla_api.py
+++ b/src/ayla_api.py
@@ -561,6 +561,7 @@ class AylaApi:
         "pause": (PROP_SET_OPERATING_MODE, OperatingMode.PAUSE),
         "return_to_base": (PROP_SET_OPERATING_MODE, OperatingMode.RETURN),
         "locate": (PROP_SET_FIND_DEVICE, 1),
+        "vacuum_and_mop": (PROP_SET_OPERATING_MODE, OperatingMode.VACUUM_AND_MOP),
     }
 
     async def send_command(self, dsn: str, command: str) -> None:

--- a/src/const.py
+++ b/src/const.py
@@ -130,6 +130,12 @@ PROP_GET_SCHEDULE = "GET_Schedule"
 # eco/normal/max scale as Power_Mode — confirmed against the SharkClean
 # app's "Water Flow Level" slider on a RV2820YEUS unit.
 PROP_GET_FLOW_MODE = "GET_Flow_Mode"
+# Wet/mop capability signals — presence in the shadow identifies
+# mop-capable (water flow level) and wet/dry-capable (wet/dry/deep
+# clean modes) device families. All dry-only models (e.g. AV251WAXUS)
+# report Flow_Mode but lack both of these.
+PROP_GET_MOP_PLATE_ATTACHED = "GET_MopPlateAttached"
+PROP_GET_CLEANING_PARAMETERS = "GET_CleaningParameters"
 
 # Write properties (used with POST /datapoints.json)
 PROP_SET_OPERATING_MODE = "SET_Operating_Mode"

--- a/src/mqtt_client.py
+++ b/src/mqtt_client.py
@@ -27,7 +27,9 @@ class MqttClient:
         self._config = config
         self._prefix = config.mqtt_prefix
         self._client: aiomqtt.Client | None = None
-        self._clean_modes: dict[str, str] = {}  # device_id -> "Normal" or "Matrix"
+        # device_id -> clean mode: "Normal"/"Matrix" for dry-only models,
+        # "Wet"/"Dry" for wet/dry-capable models (CleaningParameters present)
+        self._clean_modes: dict[str, str] = {}
         self._fan_speed_overrides: dict[str, str] = {}  # device_id -> user-set speed
         self._water_flow_overrides: dict[str, str] = {}  # device_id -> user-set flow level
         self._published_rooms: dict[str, set[str]] = {}  # device_id -> room slugs
@@ -80,6 +82,7 @@ class MqttClient:
                 "device": device.device_info,
                 "rooms": device.rooms,
                 "has_flow_mode": device.has_flow_mode,
+                "has_wet_dry": device.has_wet_dry,
             },
             sort_keys=True,
         )
@@ -401,7 +404,17 @@ class MqttClient:
                     retain=True,
                 )
 
-            # Clean mode select (Normal vs Matrix)
+            # Clean mode select. Wet/dry-capable models (CleaningParameters
+            # present) clean the same rooms in wet (hard floors) or dry
+            # (whole room incl. carpet) mode, with a separate Deep button
+            # for the two-stage dry-then-mop run. Other models use the
+            # legacy Normal vs Matrix single-stage modes.
+            if device.has_wet_dry:
+                options = ["Wet", "Dry"]
+                default_mode = "Dry"
+            else:
+                options = ["Normal", "Matrix"]
+                default_mode = "Normal"
             await self._publish(
                 f"{HA_DISCOVERY_PREFIX}/select/{uid}_clean_mode/config",
                 {
@@ -410,7 +423,7 @@ class MqttClient:
                     "object_id": f"{slug}_clean_mode",
                     "command_topic": f"{self._prefix}/{dsn}/clean_mode",
                     "state_topic": f"{self._prefix}/{dsn}/clean_mode/state",
-                    "options": ["Normal", "Matrix"],
+                    "options": options,
                     "icon": "mdi:broom",
                     "availability_topic": f"{self._prefix}/{dsn}/available",
                     "payload_available": "online",
@@ -420,8 +433,35 @@ class MqttClient:
                 retain=True,
             )
 
+            # Deep clean button (wet/dry models only): dry pass on carpet
+            # areas, then wet pass on hard floors.
+            if device.has_wet_dry:
+                await self._publish(
+                    f"{HA_DISCOVERY_PREFIX}/button/{uid}_deep/config",
+                    {
+                        "name": "Deep",
+                        "unique_id": f"{uid}_deep",
+                        "object_id": f"{slug}_deep",
+                        "command_topic": f"{self._prefix}/{dsn}/send_command",
+                        "payload_press": "vacuum_and_mop",
+                        "icon": "mdi:water-pump",
+                        "availability_topic": f"{self._prefix}/{dsn}/available",
+                        "payload_available": "online",
+                        "payload_not_available": "offline",
+                        "device": device.device_info,
+                    },
+                    retain=True,
+                )
+            else:
+                await self._publish(
+                    f"{HA_DISCOVERY_PREFIX}/button/{uid}_deep/config",
+                    "", retain=True,
+                )
+
             # Publish current clean mode state
-            mode = self._clean_modes.get(dsn, "Normal")
+            mode = self._clean_modes.get(dsn, default_mode)
+            if mode not in options:
+                mode = default_mode
             await self._publish(
                 f"{self._prefix}/{dsn}/clean_mode/state", mode, retain=True,
             )
@@ -557,7 +597,8 @@ class MqttClient:
                     )
                 elif topic.endswith("/clean_mode"):
                     mode = payload.strip()
-                    if mode in ("Normal", "Matrix"):
+                    valid_modes = ("Normal", "Matrix", "Wet", "Dry")
+                    if mode in valid_modes:
                         self._clean_modes[device_id] = mode
                         await self._publish(
                             f"{self._prefix}/{device_id}/clean_mode/state",
@@ -590,11 +631,24 @@ class MqttClient:
             logger.warning("clean_room button: no floor_id for %s", device_id)
             return
 
-        mode = self._clean_modes.get(device_id, "Normal")
-        if mode == "Matrix":
-            api_mode, clean_count = "UltraClean", 2
-        else:
+        wet_dry = bool(device and getattr(device, "has_wet_dry", False))
+        if wet_dry:
+            # Wet/dry models: the select drives clean_type, and room runs
+            # are always single-stage UserRoom (Deep is its own button).
+            mode = self._clean_modes.get(device_id)
+            if mode not in ("Wet", "Dry"):
+                mode = "Dry"
+            clean_type = "wet" if mode == "Wet" else "dry"
             api_mode, clean_count = "UserRoom", 1
+        else:
+            mode = self._clean_modes.get(device_id, "Normal")
+            if mode not in ("Normal", "Matrix"):
+                mode = "Normal"
+            clean_type = "dry"
+            if mode == "Matrix":
+                api_mode, clean_count = "UltraClean", 2
+            else:
+                api_mode, clean_count = "UserRoom", 1
 
         use_v3 = getattr(device, "has_areas_v3", False)
         api_rooms = (
@@ -604,7 +658,7 @@ class MqttClient:
         )
         await handler.clean_rooms(
             device_id, rooms=api_rooms, floor_id=floor_id,
-            clean_type="dry", clean_count=clean_count, mode=api_mode,
+            clean_type=clean_type, clean_count=clean_count, mode=api_mode,
             use_v3=use_v3,
         )
         logger.info(

--- a/src/shark_device.py
+++ b/src/shark_device.py
@@ -13,6 +13,7 @@ from .const import (
     PowerMode,
     PROP_GET_BATTERY_CAPACITY,
     PROP_GET_CHARGING_STATUS,
+    PROP_GET_CLEANING_PARAMETERS,
     PROP_GET_DEVICE_MODEL_NUMBER,
     PROP_GET_DOCK_ERROR_CODE,
     PROP_GET_DOCK_KNOB_STATUS,
@@ -23,6 +24,7 @@ from .const import (
     PROP_GET_EVACUATING,
     PROP_GET_EXTENDED_ERROR_CODE,
     PROP_GET_FLOW_MODE,
+    PROP_GET_MOP_PLATE_ATTACHED,
     PROP_GET_OPERATING_MODE,
     PROP_GET_POWER_MODE,
     PROP_GET_RECOMMEND_RANDR,
@@ -312,13 +314,27 @@ class SharkVacuum:
 
     @property
     def has_flow_mode(self) -> bool:
-        """Whether this model has a mop tank with a water flow setting.
+        """Whether this model has a mop plate with a water flow setting.
 
-        Only vac+mop combo models carry Flow_Mode in their shadow. Both
-        backends land properties in `_properties` under the `GET_` name,
-        so this works for skegox and Ayla alike.
+        Flow_Mode alone is NOT a reliable signal — dry-only models
+        (e.g. AV251WAXUS) and wet/dry models (UR2850ZEUS) also report it.
+        MopPlateAttached is only present on models with a physical mop
+        plate, so it is the capability gate for the water flow level
+        select. Both backends land properties in `_properties` under the
+        `GET_` name, so this works for skegox and Ayla alike.
         """
-        return PROP_GET_FLOW_MODE in self._properties
+        return PROP_GET_MOP_PLATE_ATTACHED in self._properties
+
+    @property
+    def has_wet_dry(self) -> bool:
+        """Whether this model supports wet/dry/deep clean modes.
+
+        CleaningParameters (e.g. '{"Dry":1,"Wet":0,"Deep":0,"CleanStage":2}')
+        is only present on wet/dry-capable models such as the UR2850ZEUS
+        and RV2820YEUS. Its value is live clean state, not a capability
+        flag — only the property's PRESENCE is the signal.
+        """
+        return PROP_GET_CLEANING_PARAMETERS in self._properties
 
     @property
     def rssi(self) -> int:
@@ -417,8 +433,8 @@ class SharkVacuum:
             "replace_battery": self.replace_battery,
             "recommend_rest_and_recharge": self.recommend_rest_and_recharge,
         }
-        # Vac-only models have no mop tank, so reporting a water flow level
-        # for them would be inventing a setting the hardware doesn't have.
+        # Models without a mop plate (vac-only or wet/dry models whose
+        # Flow_Mode is unused) would get an invented water flow setting.
         if self.has_flow_mode:
             attrs["water_flow"] = self.water_flow
         if self.rooms:

--- a/tests/test_command_event_integration.py
+++ b/tests/test_command_event_integration.py
@@ -249,3 +249,80 @@ async def test_clean_mode_updates_state():
     assert mqtt._clean_modes[dsn] == "Matrix"
 
 
+# --- Wet/dry models (CleaningParameters present) ---
+
+
+def _make_wet_dry_device(dsn: str) -> SharkVacuum:
+    device = SharkVacuum.from_skegox(make_skegox_device(dsn=dsn))
+    device.floor_id = "FLOOR1"
+    device.rooms = ["Kitchen"]
+    device._properties["GET_CleaningParameters"] = (
+        '{"CleanStage":2,"Deep":0,"Wet":0,"Dry":1}'
+    )
+    assert device.has_wet_dry is True
+    return device
+
+
+@pytest.mark.asyncio
+async def test_wet_dry_room_button_defaults_to_dry_clean_type():
+    """Wet/dry models: room button dispatches clean_type from the select."""
+    dsn = "DSN123"
+    device = _make_wet_dry_device(dsn)
+    devices = {dsn: device}
+
+    handler = AsyncMock()
+    messages = [FakeMessage(f"shark2mqtt/{dsn}/clean_room", '{"room": "Kitchen"}')]
+
+    await _run_listener_with_messages(messages, devices, handler=handler)
+
+    handler.clean_rooms.assert_awaited_once_with(
+        dsn, rooms=["Kitchen"], floor_id="FLOOR1",
+        clean_type="dry", clean_count=1, mode="UserRoom",
+        use_v3=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_wet_dry_room_button_wet_mode():
+    """Wet mode select drives clean_type=wet on room cleans."""
+    dsn = "DSN123"
+    device = _make_wet_dry_device(dsn)
+    devices = {dsn: device}
+
+    handler = AsyncMock()
+    messages = [
+        FakeMessage(f"shark2mqtt/{dsn}/clean_mode", "Wet"),
+        FakeMessage(f"shark2mqtt/{dsn}/clean_room", '{"room": "Kitchen"}'),
+    ]
+
+    await _run_listener_with_messages(messages, devices, handler=handler)
+
+    handler.clean_rooms.assert_awaited_once_with(
+        dsn, rooms=["Kitchen"], floor_id="FLOOR1",
+        clean_type="wet", clean_count=1, mode="UserRoom",
+        use_v3=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_wet_dry_stale_matrix_mode_ignored():
+    """A stale Matrix mode must not map to UltraClean on wet/dry models."""
+    dsn = "DSN123"
+    device = _make_wet_dry_device(dsn)
+    devices = {dsn: device}
+
+    handler = AsyncMock()
+    messages = [
+        FakeMessage(f"shark2mqtt/{dsn}/clean_mode", "Matrix"),
+        FakeMessage(f"shark2mqtt/{dsn}/clean_room", '{"room": "Kitchen"}'),
+    ]
+
+    await _run_listener_with_messages(messages, devices, handler=handler)
+
+    handler.clean_rooms.assert_awaited_once_with(
+        dsn, rooms=["Kitchen"], floor_id="FLOOR1",
+        clean_type="dry", clean_count=1, mode="UserRoom",
+        use_v3=False,
+    )
+
+

--- a/tests/test_shark_device.py
+++ b/tests/test_shark_device.py
@@ -30,12 +30,32 @@ def make_mop_vacuum(
     docked_status: int = 1,
     charging_status: int = 0,
 ) -> SharkVacuum:
-    """A vac+mop combo model — i.e. one whose shadow carries Flow_Mode."""
+    """A vac+mop combo model — i.e. one whose shadow carries a mop plate."""
     data = make_skegox_device(operating_mode=operating_mode)
     reported = data["shadow"]["properties"]["reported"]
     reported["DockedStatus"]["value"] = docked_status
     reported["Charging_Status"]["value"] = charging_status
     reported["Flow_Mode"] = {"value": flow_mode}
+    reported["MopPlateAttached"] = {"value": True}
+    return SharkVacuum.from_skegox(data)
+
+
+def make_wet_dry_vacuum(
+    flow_mode: int = 1,
+    operating_mode: int = 0,
+    docked_status: int = 1,
+    charging_status: int = 0,
+) -> SharkVacuum:
+    """A wet/dry model (UR2850ZEUS) — mop plate plus CleaningParameters."""
+    data = make_skegox_device(operating_mode=operating_mode)
+    reported = data["shadow"]["properties"]["reported"]
+    reported["DockedStatus"]["value"] = docked_status
+    reported["Charging_Status"]["value"] = charging_status
+    reported["Flow_Mode"] = {"value": flow_mode}
+    reported["MopPlateAttached"] = {"value": True}
+    reported["CleaningParameters"] = {
+        "value": '{"CleanStage":2,"Deep":0,"Wet":0,"Dry":1}',
+    }
     return SharkVacuum.from_skegox(data)
 
 
@@ -141,12 +161,20 @@ class TestWaterFlow:
 
 
 class TestFlowModeCapability:
-    """Vac-only models must not advertise a mop control they can't honour."""
+    """Only models with a mop plate may advertise a water flow control."""
 
-    def test_absent_flow_mode_is_not_a_capability(self):
+    def test_absent_mop_plate_is_not_a_capability(self):
         assert make_vacuum().has_flow_mode is False
 
-    def test_present_flow_mode_is_a_capability(self):
+    def test_flow_mode_alone_is_not_a_capability(self):
+        # Dry-only models (AV251WAXUS) report Flow_Mode without a mop plate.
+        data = make_skegox_device()
+        data["shadow"]["properties"]["reported"]["Flow_Mode"] = {"value": 1}
+        vac = SharkVacuum.from_skegox(data)
+        assert vac.has_flow_mode is False
+        assert "water_flow" not in vac.to_attributes_payload()
+
+    def test_present_mop_plate_is_a_capability(self):
         assert make_mop_vacuum(flow_mode=1).has_flow_mode is True
 
     def test_capability_holds_even_for_out_of_range_values(self):
@@ -158,6 +186,24 @@ class TestFlowModeCapability:
 
     def test_attributes_include_water_flow_for_mop_models(self):
         assert "water_flow" in make_mop_vacuum(flow_mode=2).to_attributes_payload()
+
+
+class TestWetDryCapability:
+    """Wet/dry models are identified by CleaningParameters presence."""
+
+    def test_absent_cleaning_parameters_is_not_wet_dry(self):
+        assert make_vacuum().has_wet_dry is False
+        assert make_mop_vacuum().has_wet_dry is False
+
+    def test_present_cleaning_parameters_is_wet_dry(self):
+        assert make_wet_dry_vacuum().has_wet_dry is True
+
+    def test_wet_dry_models_also_have_mop_plate(self):
+        # Real captures (UR2850ZEUS, RV2820YEUS) carry both properties.
+        vac = make_wet_dry_vacuum()
+        assert vac.has_wet_dry is True
+        assert vac.has_flow_mode is True
+        assert "water_flow" in vac.to_attributes_payload()
 
     @pytest.mark.asyncio
     async def test_discovery_retracts_select_for_vac_only(self, mock_config):
@@ -261,3 +307,84 @@ class TestDiscoveryDedup:
         vac.rooms = ["Kitchen"]
         await client.publish_discovery(vac)
         assert client._publish.call_count > first_count
+
+
+class TestWetDryDiscovery:
+    """Wet/dry models get a Wet/Dry clean mode select + Deep button;
+    everything else keeps Normal/Matrix and has the Deep button retracted."""
+
+    @pytest.fixture
+    def client(self, mock_config):
+        client = MqttClient(mock_config)
+        client._publish = AsyncMock()
+        return client
+
+    def _clean_mode_config(self, client):
+        for call in client._publish.call_args_list:
+            if "_clean_mode/config" in call.args[0]:
+                return call.args[1]
+        return None
+
+    def _deep_button_config(self, client):
+        for call in client._publish.call_args_list:
+            topic = call.args[0]
+            if "/button/" in topic and topic.endswith("_deep/config"):
+                return call.args[1]
+        return None
+
+    @pytest.mark.asyncio
+    async def test_wet_dry_device_gets_wet_dry_select(self, client):
+        vac = make_wet_dry_vacuum()
+        vac.rooms = ["Kitchen"]
+        await client.publish_discovery(vac)
+        config = self._clean_mode_config(client)
+        assert config["options"] == ["Wet", "Dry"]
+
+    @pytest.mark.asyncio
+    async def test_wet_dry_device_gets_deep_button(self, client):
+        vac = make_wet_dry_vacuum()
+        vac.rooms = ["Kitchen"]
+        await client.publish_discovery(vac)
+        config = self._deep_button_config(client)
+        assert config is not None
+        assert config["payload_press"] == "vacuum_and_mop"
+
+    @pytest.mark.asyncio
+    async def test_wet_dry_state_defaults_to_dry(self, client):
+        vac = make_wet_dry_vacuum()
+        vac.rooms = ["Kitchen"]
+        await client.publish_discovery(vac)
+        states = [
+            (c.args[0], c.args[1]) for c in client._publish.call_args_list
+            if c.args[0].endswith("/clean_mode/state")
+        ]
+        assert states and states[-1][1] == "Dry"
+
+    @pytest.mark.asyncio
+    async def test_dry_only_device_keeps_normal_matrix_select(self, client):
+        vac = make_vacuum()
+        vac.rooms = ["Kitchen"]
+        await client.publish_discovery(vac)
+        config = self._clean_mode_config(client)
+        assert config["options"] == ["Normal", "Matrix"]
+
+    @pytest.mark.asyncio
+    async def test_deep_button_retracted_for_dry_only_devices(self, client):
+        vac = make_vacuum()
+        vac.rooms = ["Kitchen"]
+        await client.publish_discovery(vac)
+        config = self._deep_button_config(client)
+        assert config is not None
+        assert config == ""
+
+    @pytest.mark.asyncio
+    async def test_stale_matrix_mode_falls_back_to_dry(self, client):
+        vac = make_wet_dry_vacuum()
+        vac.rooms = ["Kitchen"]
+        client._clean_modes[vac.dsn] = "Matrix"  # stale from an older model
+        await client.publish_discovery(vac)
+        states = [
+            (c.args[0], c.args[1]) for c in client._publish.call_args_list
+            if c.args[0].endswith("/clean_mode/state")
+        ]
+        assert states and states[-1][1] == "Dry"


### PR DESCRIPTION
Adds per-model clean mode settings for wet/dry vacuums and fixes Water Flow being shown on dry-only models.

**Problem**
- "Steve McClean" (UR2850ZEUS, wet/dry) showed the generic Clean Mode select with Normal/Matrix, which its hardware does not support. It needs a Wet/Dry mode select plus a Deep button (dry pass on carpet, then wet pass on floors).
- "Clean Elizabeth" (AV251WAXUS, dry-only) showed a Water Flow Level select even though it has no mop hardware. Root cause: the gate was `Flow_Mode` presence in the shadow, and all three model families report that property.

**Detection (two shadow properties, presence = capability)**
- Water Flow Level select + attribute → `MopPlateAttached` present (replaces the `Flow_Mode` gate). Dry-only models report `Flow_Mode` but lack the mop plate, so the entity is now retracted with an empty retained payload.
- Wet/Dry select + Deep button → `CleaningParameters` present (UR2850ZEUS, RV2820YEUS). The value is live clean state, so only its presence is used as the signal.

**Behavior**
- Wet/dry models: Clean Mode select becomes [Wet, Dry] (default Dry); a Deep button is published that sends `vacuum_and_mop` (Operating_Mode 8). Room-button cleans now pass `clean_type` from the select state (Wet→`wet`, Dry→`dry`), always as single-stage UserRoom.
- Other models: unchanged Normal/Matrix behavior; Deep button explicitly retracted so stale entities are deleted.
- Added `vacuum_and_mop` to the Ayla command map (Skegox already had it).

**Tests**: 66 passing. New coverage for both capability gates (including Flow_Mode-without-mop-plate), Wet/Dry discovery options, Deep button publish/retract, and clean_type routing on room-button dispatch.
